### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.1.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ It must contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## First Run
 
 ### First Generation Hue Bridge

--- a/actions/alert.yaml
+++ b/actions/alert.yaml
@@ -1,6 +1,6 @@
 ---
 name: alert
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Send an alert to a light"
 enabled: true
 entry_point: "alert.py"

--- a/actions/brightness.yaml
+++ b/actions/brightness.yaml
@@ -1,6 +1,6 @@
 ---
 name: brightness
-runner_type: "run-python"
+runner_type: "python-script"
 description: Change the brightness of a bulb
 enabled: true
 entry_point: 'brightness.py'

--- a/actions/color_temp_kelvin.yaml
+++ b/actions/color_temp_kelvin.yaml
@@ -1,6 +1,6 @@
 ---
 name: color_temp_kelvin
-runner_type: "run-python"
+runner_type: "python-script"
 description: Change the bulb color temperature to a specific temperature in Kelvin
 enabled: true
 entry_point: "color_temp_kelvin.py"

--- a/actions/color_temp_mired.yaml
+++ b/actions/color_temp_mired.yaml
@@ -1,6 +1,6 @@
 ---
 name: color_temp_mired
-runner_type: "run-python"
+runner_type: "python-script"
 description: Change the bulb color temperature to a specific temperature in mired scale
 enabled: true
 entry_point: "color_temp_mired.py"

--- a/actions/current_state.yaml
+++ b/actions/current_state.yaml
@@ -1,6 +1,6 @@
 ---
 name: current_state
-runner_type: "run-python"
+runner_type: "python-script"
 description: Get current state of bridge
 enabled: true
 entry_point: "current_state.py"

--- a/actions/find_id_by_name.yaml
+++ b/actions/find_id_by_name.yaml
@@ -1,6 +1,6 @@
 ---
 name: find_id_by_name
-runner_type: "run-python"
+runner_type: "python-script"
 description: Find bulb ID based on nickname
 enabled: true
 entry_point: "find_id_by_name.py"

--- a/actions/list_bulbs.yaml
+++ b/actions/list_bulbs.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_bulbs
-runner_type: "run-python"
+runner_type: "python-script"
 description: List all registered bulbs
 enabled: true
 entry_point: "list_bulbs.py"

--- a/actions/off.yaml
+++ b/actions/off.yaml
@@ -1,6 +1,6 @@
 ---
 name: "off"
-runner_type: "run-python"
+runner_type: "python-script"
 description: Turn off a bulb
 enabled: true
 entry_point: "off.py"

--- a/actions/on.yaml
+++ b/actions/on.yaml
@@ -1,6 +1,6 @@
 ---
 name: "on"
-runner_type: "run-python"
+runner_type: "python-script"
 description: Turn on a bulb
 enabled: true
 entry_point: "on.py"

--- a/actions/rgb.yaml
+++ b/actions/rgb.yaml
@@ -1,6 +1,6 @@
 ---
 name: rgb
-runner_type: "run-python"
+runner_type: "python-script"
 description: Change bulb color based on RGB Values
 enabled: true
 entry_point: "rgb.py"

--- a/actions/set_state.yaml
+++ b/actions/set_state.yaml
@@ -1,6 +1,6 @@
 ---
 name: set_state
-runner_type: "run-python"
+runner_type: "python-script"
 description: Send manual state to bulb
 enabled: true
 entry_point: "set_state.py"

--- a/actions/toggle.yaml
+++ b/actions/toggle.yaml
@@ -1,6 +1,6 @@
 ---
 name: toggle
-runner_type: "run-python"
+runner_type: "python-script"
 description: Toggle on/off state of a bulb
 enabled: true
 entry_point: "toggle.py"

--- a/actions/xy.yaml
+++ b/actions/xy.yaml
@@ -1,6 +1,6 @@
 ---
 name: xy
-runner_type: "run-python"
+runner_type: "python-script"
 description: Change bulb color based on CIE color space values
 enabled: true
 entry_point: "xy.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -3,7 +3,7 @@
 ref: hue
 name: hue
 description: Philips Hue Pack
-version: 0.0.2
+version: 0.1.0
 author: James Fryman
 email: james@stackstorm.com
 keywords:


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.